### PR TITLE
fix: inline scrolloop/core and scrolloop/shared into scrolloop bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scrolloop",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/976520/scrolloop.git"
@@ -98,9 +98,5 @@
     "vitepress": "^1.6.4",
     "vitest": "^2.0.0",
     "vue": "^3.5.26"
-  },
-  "dependencies": {
-    "@scrolloop/core": "workspace:*",
-    "@scrolloop/shared": "workspace:*"
   }
 }

--- a/packages/react-native/src/types.ts
+++ b/packages/react-native/src/types.ts
@@ -1,8 +1,16 @@
 import type { ReactNode } from "react";
 import type { ViewStyle, ScrollViewProps } from "react-native";
-import type { PageResponse, Range } from "@scrolloop/shared";
 
-export type { PageResponse, Range };
+export interface Range {
+  startIndex: number;
+  endIndex: number;
+}
+
+export interface PageResponse<T> {
+  items: T[];
+  total: number;
+  hasMore: boolean;
+}
 
 export interface ItemProps {
   key: number | string;

--- a/packages/react-native/tsup.config.ts
+++ b/packages/react-native/tsup.config.ts
@@ -28,7 +28,8 @@ export default defineConfig({
     },
   },
   target: "es2020",
-  external: ["react", "react-native", "@scrolloop/core", "@scrolloop/shared"],
+  external: ["react", "react-native"],
+  noExternal: ["@scrolloop/core", "@scrolloop/shared"],
   outExtension({ format }) {
     return {
       js: format === "esm" ? ".mjs" : ".cjs",

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -1,7 +1,15 @@
 import type { CSSProperties, ReactNode, HTMLAttributes } from "react";
-import type { PageResponse, Range } from "@scrolloop/shared";
 
-export type { PageResponse, Range };
+export interface Range {
+  startIndex: number;
+  endIndex: number;
+}
+
+export interface PageResponse<T> {
+  items: T[];
+  total: number;
+  hasMore: boolean;
+}
 
 export type TransitionState =
   | { type: "SSR_DOM" }

--- a/packages/react/tsup.config.ts
+++ b/packages/react/tsup.config.ts
@@ -28,7 +28,8 @@ export default defineConfig({
     },
   },
   target: "es2020",
-  external: ["react", "react-dom", "@scrolloop/core", "@scrolloop/shared"],
+  external: ["react", "react-dom"],
+  noExternal: ["@scrolloop/core", "@scrolloop/shared"],
   outExtension({ format }) {
     return {
       js: format === "esm" ? ".mjs" : ".cjs",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,13 +7,6 @@ settings:
 importers:
 
   .:
-    dependencies:
-      '@scrolloop/core':
-        specifier: workspace:*
-        version: link:packages/core
-      '@scrolloop/shared':
-        specifier: workspace:*
-        version: link:packages/shared
     devDependencies:
       '@testing-library/jest-dom':
         specifier: ^6.0.0


### PR DESCRIPTION
## Summary
- Published `scrolloop@0.5.1` declared `@scrolloop/core` and `@scrolloop/shared` as runtime deps, but those packages aren't on npm — `npm install scrolloop` fails to resolve them.
- Force-bundle both into the adapter builds via tsup `noExternal`, and duplicate `Range` / `PageResponse` interfaces in the adapter packages so the public `.d.ts` is also self-contained (tsup `dts.resolve` wasn't inlining workspace package types reliably).
- Bumps version to `0.5.2` (0.5.1 on npm is immutable and broken).

## Test plan
- [x] `pnpm run build` — all 6 packages build successfully
- [x] `pnpm run typecheck` — passes
- [x] `pnpm run test` — 21 tests pass
- [x] `dist/index.{cjs,mjs,d.ts,d.cts}` contain zero references to `@scrolloop/*` after build
- [x] `npm pack` tarball has no runtime `dependencies`, only `peerDependencies: { react: '>=18.0.0' }`
- [ ] CI publish job succeeds → `scrolloop@0.5.2` on npm is installable standalone

🤖 Generated with [Claude Code](https://claude.com/claude-code)