### PR TITLE
fix: resync pnpm-lock to match installed tsup variant

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,7 +101,7 @@ importers:
         version: 10.28.0
       tsup:
         specifier: ^8.0.0
-        version: 8.5.0(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
+        version: 8.5.0(@microsoft/api-extractor@7.57.7(@types/node@24.10.0))(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
       typescript:
         specifier: ^5.0.0
         version: 5.9.3


### PR DESCRIPTION
The lockfile referenced tsup 8.5.0 without the @microsoft/api-extractor peer, but the variant materialized on disk includes it. The mismatch left preact/svelte/vue/react-native node_modules/tsup symlinks pointing to a non-existent .pnpm directory, breaking 'tsup' invocation during build.